### PR TITLE
Improve Keeper login checks and CLI compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Keeper Credential Ownership Transfer PowerShell Script
-Version: 2.22 (as per the script this README is based on)
+Version: 2.24 (as per the script this README is based on)
 
 Overview
 This PowerShell script automates the process of transferring ownership of all credentials within specified Keeper Shared Folders or those accessible via Keeper Teams to a designated Keeper user. It is designed for administrators who need to manage credential ownership in bulk, for instance, during employee off-boarding or role changes.
@@ -176,7 +176,7 @@ Configuration File Example (keeper_transfer_config.json)
 {
   "NewOwnerEmail": "new.owner@example.com",
   "LogDetail": "SilentlyContinue",
-  "ScriptConfigVersion": "2.22",
+  "ScriptConfigVersion": "2.24",
   "NoRecursive": false,
   "SelectedTeams": [
     {
@@ -192,7 +192,7 @@ Or for specific folders:
 {
   "NewOwnerEmail": "new.owner@example.com",
   "LogDetail": "Verbose",
-  "ScriptConfigVersion": "2.22",
+  "ScriptConfigVersion": "2.24",
   "NoRecursive": true,
   "SelectedSharedFolders": [
     {


### PR DESCRIPTION
## Summary
- update script and README to version 2.24
- add a `Test-KeeperSession` helper to verify Keeper login
- retry commands with `--format=json` when old CLI syntax causes errors
- prompt the user to login again if no Keeper session is found

## Testing
- `pwsh -NoProfile -File 'Change owner.ps1' -RunAutomated -ConfigFilePath dummy_config.json -WhatIf -Verbose` *(fails: keeper-commander.exe not found)*