### PR TITLE
Enable interactive Keeper login

### DIFF
--- a/Change owner.ps1
+++ b/Change owner.ps1
@@ -15,8 +15,7 @@
       that were previously identified for specific teams.
 
     IMPORTANT: 
-    1. Ensure you are logged into Keeper Commander (e.g., via 'keeper-commander.exe shell' then 'exit')
-       IN THE SAME POWERSHELL WINDOW before running this script interactively.
+    1. If an active Keeper session is not detected, the script launches the Keeper shell so you can log in and then continue.
     2. This script attempts to use JSON output (--format json) from Keeper CLI commands.
        If JSON fails, it falls back to text parsing which can be fragile.
     3. Out-GridView requires a graphical environment (WPF). If not available, the script
@@ -228,6 +227,11 @@ Function Test-KeeperSession {
     }
     return $false
 }
+Function Invoke-KeeperLoginShell {
+    Write-Host "`nLaunching Keeper shell for login. Type 'quit' when done." -ForegroundColor Cyan
+    & $Global:KeeperExecutablePath shell
+}
+
 
 Function Select-FromConsoleMenu {
     param(
@@ -511,9 +515,8 @@ try {
         Write-Host "`nVerifying Keeper login..." -ForegroundColor Yellow
         $sessionOk = Test-KeeperSession
         if (-not $sessionOk) {
-            Write-Warning "No active Keeper session detected. Log in via "keeper-commander.exe shell" in another window."
-            $resp = Read-Host "Press Enter when logged in or type Q to quit"
-            if ($resp -and $resp.StartsWith("q", [System.StringComparison]::OrdinalIgnoreCase)) { Write-Host "Exiting."; Exit 0 }
+            Write-Warning "No active Keeper session detected. Launching Keeper shell for login. Type 'quit' when finished."
+            Invoke-KeeperLoginShell
             $sessionOk = Test-KeeperSession
             if (-not $sessionOk) { Write-Error "Keeper login still not verified. Exiting."; Exit 1 }
         }

--- a/README.md
+++ b/README.md
@@ -35,17 +35,8 @@ The ability to transfer ownership of records.
 
 Authenticated Keeper Session (for interactive use):
 
-Before running interactively, log in to Keeper Commander in the same PowerShell window:
-
-Open PowerShell.
-
-Run keeper-commander.exe shell.
-
-Log in with your master password and 2FA.
-
-Type exit to leave the Keeper shell (the session remains active for that window).
-
-Then, run this script.
+When run interactively, the script now launches the Keeper Commander shell so you can log in directly.
+Type `quit` once authenticated to return and continue with the script.
 
 The script includes a basic login check using keeper-commander.exe whoami.
 
@@ -121,19 +112,17 @@ Script Parameters
 
 How to Use
 1. Interactive Mode
-Login to Keeper: Open PowerShell, run keeper-commander.exe shell, log in, then exit the shell.
-
-Run Script: In the same PowerShell window:
+Run Script:
 
 .\keeper_ownership_transfer.ps1
 
+The script launches the Keeper shell for login; type `quit` when done.
 (Or use the full path to the script).
 
 Follow Prompts:
 
 Select log detail level.
 
-Confirm login status.
 
 Choose "Teams" or "Shared Folders".
 


### PR DESCRIPTION
## Summary
- allow script to open Keeper shell for login
- update README instructions for new interactive login
- clarify that Keeper shell should be exited with `quit`

## Testing
- `pwsh -NoProfile -Command "Write-Host 'PowerShell available.'"`
