### PR TITLE
Enable login shell prompt with persistent login option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Keeper Credential Ownership Transfer PowerShell Script
-Version: 2.24 (as per the script this README is based on)
+Version: 2.25 (as per the script this README is based on)
 
 Overview
 This PowerShell script automates the process of transferring ownership of all credentials within specified Keeper Shared Folders or those accessible via Keeper Teams to a designated Keeper user. It is designed for administrators who need to manage credential ownership in bulk, for instance, during employee off-boarding or role changes.
@@ -35,17 +35,10 @@ The ability to transfer ownership of records.
 
 Authenticated Keeper Session (for interactive use):
 
-Before running interactively, log in to Keeper Commander in the same PowerShell window:
+When run interactively, the script launches the Keeper Commander shell so you can log in or confirm your session.
+Type `quit` once authenticated (or if already logged in) to return and continue with the script.
 
-Open PowerShell.
-
-Run keeper-commander.exe shell.
-
-Log in with your master password and 2FA.
-
-Type exit to leave the Keeper shell (the session remains active for that window).
-
-Then, run this script.
+After login verification, the script asks if you want to enable persistent login for future automated runs. Choosing **Yes** opens the Keeper shell again so you can approve the device or run `setup`. Type `quit` when finished.
 
 The script includes a basic login check using keeper-commander.exe whoami.
 
@@ -121,19 +114,18 @@ Script Parameters
 
 How to Use
 1. Interactive Mode
-Login to Keeper: Open PowerShell, run keeper-commander.exe shell, log in, then exit the shell.
-
-Run Script: In the same PowerShell window:
+Run Script:
 
 .\keeper_ownership_transfer.ps1
 
+The script launches the Keeper shell for login; type `quit` when done.
+You'll then be asked if you want to enable persistent login for automation.
 (Or use the full path to the script).
 
 Follow Prompts:
 
 Select log detail level.
 
-Confirm login status.
 
 Choose "Teams" or "Shared Folders".
 
@@ -176,7 +168,7 @@ Configuration File Example (keeper_transfer_config.json)
 {
   "NewOwnerEmail": "new.owner@example.com",
   "LogDetail": "SilentlyContinue",
-  "ScriptConfigVersion": "2.24",
+  "ScriptConfigVersion": "2.25",
   "NoRecursive": false,
   "SelectedTeams": [
     {
@@ -192,7 +184,7 @@ Or for specific folders:
 {
   "NewOwnerEmail": "new.owner@example.com",
   "LogDetail": "Verbose",
-  "ScriptConfigVersion": "2.24",
+  "ScriptConfigVersion": "2.25",
   "NoRecursive": true,
   "SelectedSharedFolders": [
     {


### PR DESCRIPTION
## Summary
- open Keeper shell at runtime so users can log in or confirm their session
- instruct users to quit the shell instead of exit
- ask to enable persistent login right after login verification
- update docs for new login flow and version 2.25

## Testing
- `pwsh -NoProfile -Command "Write-Host 'PowerShell available.'"`